### PR TITLE
chore: publish to github packages

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -1,0 +1,27 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-and-publish-gpr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://npm.pkg.github.com/
+          scope: "@wiredcraft"
+      - run: yarn
+      - run: yarn lerna exec -- yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Purpose
- publish the npm packages to the GitHub packages registry by GitHub CI
- resolve registry conlict, when there are both @wiredcraft/npm packages and @wiredcraft/github packages in one single project.